### PR TITLE
Remove frequent sign-in prompts

### DIFF
--- a/src/Enrollment/Enrollment.js
+++ b/src/Enrollment/Enrollment.js
@@ -124,7 +124,6 @@ export default class Enrollment extends React.Component {
   async signUserIn() {
     let userInfo;
     try {
-      userInfo = await GoogleSignin.signIn();
       userInfo = await GoogleSignin.getCurrentUser();
       if (userInfo === null) {
         throw {code: statusCodes.SIGN_IN_REQUIRED};


### PR DESCRIPTION
fixes issue #198

To me, it looks like the line I deleted was unnecessary because if `GoogleSignin.getCurrentUser()` fails, it would call `GoogleSignin.signIn()` anyways. This will make development a lot less annoying because it asks me to sign in every time I reload the app, it shows the prompt, but signing in in those instances is redundant because if I tap outside the focused area, the app will resume as normal.